### PR TITLE
Some fixes to example scripts

### DIFF
--- a/scripts/daily_remote_download.py
+++ b/scripts/daily_remote_download.py
@@ -47,12 +47,14 @@ if __name__ == '__main__':
     with open('/home/joseph/nymar_zerotier_ips.json', 'r') as w:
         ips_dict = json.load(w)
 
+    with open('home/joseph/nymar_request_params.json', 'r') as param_file:
+        params = json.load(param_file)
+
     # Seedlink Parameters
-    networks = ["OX"]
-    stations = ['NYM1', 'NYM2', 'NYM3', 'NYM4',
-                'NYM5', 'NYM6', 'NYM7', 'NYM8']
-    channels = ["HHZ",  "HHN", "HHE"]
-    locations = ["00"]
+    networks = params["networks"]
+    stations = params["stations"]
+    channels = params["channels"]
+    locations = params["locations"]
 
     # Set number of days to downlaod (for preliminary gapfilling)
     backfill_span = datetime.timedelta(days=2)

--- a/scripts/daily_remote_download.py
+++ b/scripts/daily_remote_download.py
@@ -12,6 +12,7 @@
 
 import asyncio
 import datetime
+import itertools
 import json
 import logging
 from pathlib import Path
@@ -47,10 +48,11 @@ if __name__ == '__main__':
         ips_dict = json.load(w)
 
     # Seedlink Parameters
-    network = ["OX"]
-    station_list = ['NYM1', 'NYM2', 'NYM3', 'NYM4',
-                    'NYM5', 'NYM6', 'NYM7', 'NYM8']
+    networks = ["OX"]
+    stations = ['NYM1', 'NYM2', 'NYM3', 'NYM4',
+                'NYM5', 'NYM6', 'NYM7', 'NYM8']
     channels = ["HHZ",  "HHN", "HHE"]
+    locations = ["00"]
 
     # Set number of days to downlaod (for preliminary gapfilling)
     backfill_span = datetime.timedelta(days=2)
@@ -59,7 +61,7 @@ if __name__ == '__main__':
     # SET TO CORRECT CODE. should be '00' for veloctity data
     # will be somehing different for voltage
     # check status page (https://{your-ip-here})
-    location = ["00"]
+
     # set start / end date.
     # try to get previous 2 days of data (current day will not be available)
     # Here we want to iterate over the preding days
@@ -71,10 +73,16 @@ if __name__ == '__main__':
     log.info(f'Query end time: {end}')
     # ---------- End of variables to set ----------
 
+    request_params = itertools.product(networks,
+                                       stations,
+                                       locations,
+                                       channels,
+                                       start,
+                                       end)
     # call get_data
-    asyncio.run(get_data(network, station_list, location, channels,
-                start, end, station_ips=ips_dict,
-                data_dir=data_dir))
+    asyncio.run(get_data(request_params,
+                         station_ips=ips_dict,
+                         data_dir=data_dir))
 
     script_end = timeit.default_timer()
     runtime = script_end - script_start

--- a/scripts/daily_remote_download.py
+++ b/scripts/daily_remote_download.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     with open('/home/joseph/nymar_zerotier_ips.json', 'r') as w:
         ips_dict = json.load(w)
 
-    with open('home/joseph/nymar_request_params.json', 'r') as param_file:
+    with open('/home/joseph/nymar_request_params.json', 'r') as param_file:
         params = json.load(param_file)
 
     # Seedlink Parameters

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -56,11 +56,14 @@ if __name__ == '__main__':
     # with open('/home/joseph/nymar_zerotier_ips.json', 'r') as w:
     #     ips_dict = json.load(w)
 
+    with open('home/joseph/nymar_request_params.json', 'r') as param_file:
+        params = json.load(param_file)
+
     # Seedlink Parameters
-    networks = ["OX"]
-    stations = ['NYM1', 'NYM2', 'NYM3', 'NYM4',
-                'NYM5', 'NYM6', 'NYM7', 'NYM8']
-    channels = ["HHZ",  "HHN", "HHE"]
+    networks = params["networks"]
+    stations = params["stations"]
+    channels = params["channels"]
+    locations = params["locations"]
 
     # Time span to get data for. Edit these start/end objects
     # to customise the timespan to get data for.


### PR DESCRIPTION
All download scripts now use async functions which will improve download speed.

To make this work the combinations of SEEDlink parameters now have to be done in the script. So either you give some desired network/station/channel/location codes WITH start/end dates which will be turned into a list of tuples with all combinations to request of the form 

```
[(network, station, locaiton, channel1, start, end),
 (network, station, location, channel2, start, end)]  
 ``` 

OR as in the gapfill script you can predefine a specifi set of SEED parameters to get. this is usesul for is you have identified soem gaps in continuous data which needs filling, or if there are particular times/stations of interest (i.e., you dont want/need to get all waveform data within a time range but want specific bits)
